### PR TITLE
Dropping 1.20.3 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,10 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric (https://fabricmc.net/develop)
-# TODO: when updating to 1.21, revert "minecraft": ["1.20.3", "1.20.4"] to "minecraft": "${minecraft_version}"
 minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.1
-loader_version=0.15.0
-fapi_version=0.91.1+1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.2
+fapi_version=0.91.3+1.20.4
 
 # Mod Properties
 mod_version=0.5.6
@@ -18,13 +17,13 @@ archives_base_name=meteor-client
 baritone_version=1.20.2
 
 # Sodium (https://github.com/CaffeineMC/sodium-fabric)
-sodium_version=mc1.20.3-0.5.4
+sodium_version=mc1.20.3-0.5.5
 
 # Lithium (https://github.com/CaffeineMC/lithium-fabric)
 lithium_version=mc1.20.2-0.12.0
 
 # Iris (https://github.com/IrisShaders/Iris)
-iris_version=1.6.12+1.20.3
+iris_version=1.6.13+1.20.4
 
 # Orbit (https://github.com/MeteorDevelopment/orbit)
 orbit_version=0.2.4

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
@@ -84,7 +84,7 @@ public abstract class BookEditScreenMixin extends Screen {
                     DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
 
                     try {
-                        NbtCompound tag = NbtIo.readCompressed(in, NbtTagSizeTracker.ofUnlimitedBytes());
+                        NbtCompound tag = NbtIo.readCompressed(in, NbtSizeTracker.ofUnlimitedBytes());
 
                         NbtList listTag = tag.getList("pages", 8).copy();
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PacketByteBufMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PacketByteBufMixin.java
@@ -7,17 +7,16 @@ package meteordevelopment.meteorclient.mixin;
 
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.AntiPacketKick;
-import net.minecraft.nbt.NbtTagSizeTracker;
+import net.minecraft.nbt.NbtSizeTracker;
 import net.minecraft.network.PacketByteBuf;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(PacketByteBuf.class)
-public class PacketByteBufMixin {
-
-    @ModifyArg(method = "readNbt()Lnet/minecraft/nbt/NbtCompound;", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;readNbt(Lnet/minecraft/nbt/NbtTagSizeTracker;)Lnet/minecraft/nbt/NbtElement;"))
-    private NbtTagSizeTracker xlPackets(NbtTagSizeTracker sizeTracker) {
-        return Modules.get().isActive(AntiPacketKick.class) ? NbtTagSizeTracker.ofUnlimitedBytes() : sizeTracker;
+public abstract class PacketByteBufMixin {
+    @ModifyArg(method = "readNbt()Lnet/minecraft/nbt/NbtCompound;", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;readNbt(Lnet/minecraft/nbt/NbtSizeTracker;)Lnet/minecraft/nbt/NbtElement;"))
+    private NbtSizeTracker xlPackets(NbtSizeTracker sizeTracker) {
+        return Modules.get().isActive(AntiPacketKick.class) ? NbtSizeTracker.ofUnlimitedBytes() : sizeTracker;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtUtils.java
@@ -86,7 +86,7 @@ public class NbtUtils {
             byte[] data = Base64.getDecoder().decode(mc.keyboard.getClipboard().trim());
             ByteArrayInputStream bis = new ByteArrayInputStream(data);
 
-            NbtCompound pasted = NbtIo.readCompressed(new DataInputStream(bis), NbtTagSizeTracker.ofUnlimitedBytes());
+            NbtCompound pasted = NbtIo.readCompressed(new DataInputStream(bis), NbtSizeTracker.ofUnlimitedBytes());
             for (String key : schema.getKeys()) if (!pasted.getKeys().contains(key)) return null;
             if (!pasted.getString("name").equals(schema.getString("name"))) return null;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -45,7 +45,7 @@
   },
   "depends": {
     "java": ">=17",
-    "minecraft": ["1.20.3", "1.20.4"],
+    "minecraft": "${minecraft_version}",
     "fabricloader": ">=${loader_version}"
   },
   "breaks": {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Addons are already developing for 1.20.4 since our template targets that version.
Also, the critical decorated pots bug makes 1.20.3 unappealing to use overall.

## Related issues

None.

# How Has This Been Tested?

Single player testing.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
