### PR TITLE
Fix MC 26.2 compilation errors (VanillaTextRenderer + Excavator workaround)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
@@ -5,26 +5,14 @@
 
 package meteordevelopment.meteorclient.renderer.text;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.ByteBufferBuilder;
-import com.mojang.blaze3d.vertex.PoseStack;
+import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.utils.render.color.Color;
-import net.minecraft.client.gui.Font.DisplayMode;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.util.LightCoordsUtil;
-import org.joml.Matrix4f;
-import org.joml.Matrix4fStack;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class VanillaTextRenderer implements TextRenderer {
     public static final VanillaTextRenderer INSTANCE = new VanillaTextRenderer();
-
-    private final ByteBufferBuilder buffer = new ByteBufferBuilder(2048);
-    private final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(buffer);
-
-    private final PoseStack matrices = new PoseStack();
-    private final Matrix4f emptyMatrix = new Matrix4f();
 
     public double scale = 2;
     public boolean scaleIndividually;
@@ -73,18 +61,23 @@ public class VanillaTextRenderer implements TextRenderer {
         int preA = color.a;
         color.a = (int) (((double) color.a / 255 * alpha) * 255);
 
-        Matrix4f matrix = emptyMatrix;
-        if (scaleIndividually) {
-            matrices.pushPose();
-            matrices.scale((float) scale, (float) scale, 1);
-            matrix = matrices.last().pose();
+        GuiGraphicsExtractor graphics = HudRenderer.INSTANCE.graphics;
+        if (graphics != null) {
+            var pose = graphics.pose();
+            pose.pushMatrix();
+            pose.scale((float) scale);
+
+            if (shadow) {
+                int packed = color.getPacked();
+                int shadowColor = (packed & 0xFF000000) | ((packed & 0x00FCFCFC) >> 2);
+                graphics.text(mc.font, text, (int) (x / scale) + 1, (int) (y / scale) + 1, shadowColor);
+            }
+            graphics.text(mc.font, text, (int) (x / scale), (int) (y / scale), color.getPacked());
+
+            pose.popMatrix();
         }
 
-        mc.font.drawInBatch(text, (float) (x / scale), (float) (y / scale), color.getPacked(), shadow, matrix, immediate, DisplayMode.NORMAL, 0, LightCoordsUtil.FULL_BRIGHT);
         double x2 = (x / scale) + mc.font.width(text);
-
-        if (scaleIndividually) matrices.popPose();
-
         color.a = preA;
 
         if (!wasBuilding) end();
@@ -99,15 +92,6 @@ public class VanillaTextRenderer implements TextRenderer {
     @Override
     public void end() {
         if (!building) throw new RuntimeException("VanillaTextRenderer.end() called without calling begin()");
-
-        Matrix4fStack matrixStack = RenderSystem.getModelViewStack();
-
-        matrixStack.pushMatrix();
-        if (!scaleIndividually) matrixStack.scale((float) scale, (float) scale, 1);
-
-        immediate.endBatch();
-
-        matrixStack.popMatrix();
 
         this.scale = 2;
         this.building = false;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Excavator.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Excavator.java
@@ -88,7 +88,6 @@ public class Excavator extends Module {
     @Override
     public void onDeactivate() {
         baritone.getSelectionManager().removeSelection(baritone.getSelectionManager().getLastSelection());
-        if (baritone.getBuilderProcess().isActive()) baritone.getCommandManager().execute("stop");
         status = Status.SEL_START;
     }
 


### PR DESCRIPTION
> **Note:** This is a temporary PR to allow certain features to work more or less while upstream dependencies (Baritone) catch up to MC 26.2. It is not intended as a permanent solution.

## Summary

- **VanillaTextRenderer**: Replace removed `MultiBufferSource` / `ByteBufferBuilder` / `Font.drawInBatch` API with `GuiGraphicsExtractor.text()`. Scale applied via `graphics.pose().pushMatrix()` / `scale()` / `popMatrix()`, using the extractor already held by `HudRenderer.INSTANCE.graphics`.

- **Excavator**: Remove `baritone.getCommandManager().execute("stop")` — its return type transitively references `net.minecraft.util.Tuple` which was removed in MC 26.2, blocking compilation. This is a **temporary workaround** to unblock the build; the proper fix is a Baritone 26.2 release. The stop-on-deactivate behavior is lost until then.