### PR TITLE
Finish 26.2 build: VanillaTextRenderer + Baritone Tuple stub

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,15 @@ configurations {
     }
 }
 
+// Compile-only stubs for vanilla classes removed in 26.2 but still referenced by the (not-yet-26.2)
+// Baritone API surface. Never shipped in the jar; satisfies javac symbol resolution only.
+// Remove once a 26.2 Baritone build exists. Declared before `dependencies` so it resolves there.
+val stub: SourceSet by sourceSets.creating {
+    java {
+        srcDir("src/stub/java")
+    }
+}
+
 dependencies {
     // Fabric
     minecraft(libs.minecraft)
@@ -82,6 +91,7 @@ dependencies {
     compileOnly(libs.viafabricplus.api) { isTransitive = false }
 
     compileOnly(libs.baritone)
+    compileOnly(stub.output) // net.minecraft.util.Tuple stub for the 26.1 Baritone API
     compileOnly(libs.modmenu)
 
     // Libraries (JAR-in-JAR)

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
@@ -6,25 +6,53 @@
 package meteordevelopment.meteorclient.renderer.text;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.ByteBufferBuilder;
-import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.textures.AddressMode;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuSampler;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import meteordevelopment.meteorclient.renderer.MeshBuilder;
+import meteordevelopment.meteorclient.renderer.MeshRenderer;
+import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
 import meteordevelopment.meteorclient.utils.render.color.Color;
-import net.minecraft.client.gui.Font.DisplayMode;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.font.EmptyArea;
+import net.minecraft.client.gui.font.TextRenderable;
 import net.minecraft.util.LightCoordsUtil;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
 
+import java.util.Map;
+
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
+/**
+ * Vanilla-font text renderer ported to the 26.2 deferred text pipeline.
+ *
+ * 26.2 removed {@code MultiBufferSource}/immediate-mode {@code Font.drawInBatch}. Text is now produced by
+ * {@code Font.prepareText(...) -> PreparedText.visit(GlyphVisitor)}, where each {@link TextRenderable} renders
+ * itself into a {@link VertexConsumer} and carries its own atlas texture ({@link TextRenderable#textureView()}).
+ *
+ * We collect glyph quads (position + uv + color) into one {@link MeshBuilder} per atlas texture, then draw each
+ * with Meteor's migrated {@link MeshRenderer} using the UI_TEXT pipeline (same path {@link CustomTextRenderer} uses).
+ *
+ * ponytail: geometry/positions are exact; glyph texturing follows vanilla's atlas uvs. Cannot be runtime-verified
+ * on a headless host - if vanilla-font rendering looks off, this class is the place to check first. CustomTextRenderer
+ * (the default font) is unaffected.
+ */
 public class VanillaTextRenderer implements TextRenderer {
     public static final VanillaTextRenderer INSTANCE = new VanillaTextRenderer();
 
-    private final ByteBufferBuilder buffer = new ByteBufferBuilder(2048);
-    private final MultiBufferSource.BufferSource immediate = MultiBufferSource.immediate(buffer);
+    // One mesh per atlas texture, reused across draws to avoid re-allocating native buffers.
+    private final Map<GpuTextureView, MeshBuilder> meshes = new Object2ObjectOpenHashMap<>();
+    private final Map<GpuTextureView, Boolean> touched = new Object2ObjectOpenHashMap<>();
 
-    private final PoseStack matrices = new PoseStack();
-    private final Matrix4f emptyMatrix = new Matrix4f();
+    private final GlyphCollector collector = new GlyphCollector();
+    private final Matrix4f identity = new Matrix4f();
+
+    private GpuSampler sampler;
 
     public double scale = 2;
     public boolean scaleIndividually;
@@ -34,6 +62,16 @@ public class VanillaTextRenderer implements TextRenderer {
 
     private VanillaTextRenderer() {
         // Use INSTANCE
+    }
+
+    private GpuSampler sampler() {
+        // Vanilla font atlases: clamp + nearest.
+        if (sampler == null) {
+            sampler = RenderSystem.getSamplerCache().getSampler(
+                AddressMode.CLAMP_TO_EDGE, AddressMode.CLAMP_TO_EDGE,
+                FilterMode.NEAREST, FilterMode.NEAREST, false);
+        }
+        return sampler;
     }
 
     @Override
@@ -72,21 +110,14 @@ public class VanillaTextRenderer implements TextRenderer {
 
         int preA = color.a;
         color.a = (int) (((double) color.a / 255 * alpha) * 255);
-
-        Matrix4f matrix = emptyMatrix;
-        if (scaleIndividually) {
-            matrices.pushPose();
-            matrices.scale((float) scale, (float) scale, 1);
-            matrix = matrices.last().pose();
-        }
-
-        mc.font.drawInBatch(text, (float) (x / scale), (float) (y / scale), color.getPacked(), shadow, matrix, immediate, DisplayMode.NORMAL, 0, LightCoordsUtil.FULL_BRIGHT);
-        double x2 = (x / scale) + mc.font.width(text);
-
-        if (scaleIndividually) matrices.popPose();
-
+        int packed = color.getPacked();
         color.a = preA;
 
+        // Glyph coords are produced unscaled here; the scale is applied to the modelview in end().
+        Font.PreparedText prepared = mc.font.prepareText(text, (float) (x / scale), (float) (y / scale), packed, shadow, LightCoordsUtil.FULL_BRIGHT);
+        prepared.visit(collector);
+
+        double x2 = (x / scale) + mc.font.width(text);
         if (!wasBuilding) end();
         return (x2 - 1) * scale;
     }
@@ -100,16 +131,159 @@ public class VanillaTextRenderer implements TextRenderer {
     public void end() {
         if (!building) throw new RuntimeException("VanillaTextRenderer.end() called without calling begin()");
 
-        Matrix4fStack matrixStack = RenderSystem.getModelViewStack();
+        collector.flush();
 
+        Matrix4fStack matrixStack = RenderSystem.getModelViewStack();
         matrixStack.pushMatrix();
         if (!scaleIndividually) matrixStack.scale((float) scale, (float) scale, 1);
 
-        immediate.endBatch();
+        for (GpuTextureView texture : touched.keySet()) {
+            MeshBuilder mesh = meshes.get(texture);
+            if (mesh == null || !mesh.isBuilding()) continue;
+            mesh.end();
+
+            if (mesh.getIndicesCount() > 0) {
+                MeshRenderer.begin()
+                    .attachments(Minecraft.getInstance().gameRenderer.mainRenderTarget())
+                    .pipeline(MeteorRenderPipelines.UI_TEXT)
+                    .mesh(mesh)
+                    .sampler("u_Texture", texture, sampler())
+                    .end();
+            }
+        }
 
         matrixStack.popMatrix();
+        touched.clear();
 
         this.scale = 2;
         this.building = false;
+    }
+
+    /** Lazily starts (and returns) the mesh for a given atlas texture, marking it drawn this batch. */
+    private MeshBuilder meshFor(GpuTextureView texture) {
+        MeshBuilder mesh = meshes.computeIfAbsent(texture, t -> new MeshBuilder(MeteorRenderPipelines.UI_TEXT));
+        if (!mesh.isBuilding()) mesh.begin();
+        touched.put(texture, Boolean.TRUE);
+        return mesh;
+    }
+
+    /**
+     * Visits prepared glyphs/effects and renders each into the mesh belonging to its atlas texture via a
+     * position+uv+color {@link VertexConsumer}.
+     */
+    private final class GlyphCollector implements Font.GlyphVisitor {
+        private final QuadConsumer consumer = new QuadConsumer();
+
+        private void render(TextRenderable renderable) {
+            GpuTextureView texture = renderable.textureView();
+            if (texture == null) return; // effects without a texture (e.g. shadow-only markers) - skip
+            consumer.mesh = meshFor(texture);
+            renderable.render(identity, consumer, LightCoordsUtil.FULL_BRIGHT, false);
+            consumer.flush();
+        }
+
+        @Override
+        public void acceptGlyph(TextRenderable.Styled glyph) {
+            render(glyph);
+        }
+
+        @Override
+        public void acceptRenderable(TextRenderable renderable) {
+            render(renderable);
+        }
+
+        @Override
+        public void acceptEffect(TextRenderable effect) {
+            render(effect);
+        }
+
+        @Override
+        public void acceptEmptyArea(EmptyArea area) {
+            // Nothing to draw.
+        }
+
+        void flush() {
+            consumer.flush();
+        }
+    }
+
+    /**
+     * Buffers one vertex at a time (pos, uv, color) and emits a {@link MeshBuilder} quad every 4 vertices, matching
+     * the UI_TEXT vertex layout (vec3 position, vec2 uv, 4-byte color).
+     */
+    private static final class QuadConsumer implements VertexConsumer {
+        private MeshBuilder mesh;
+
+        private final Color color = new Color();
+        private float x, y, z, u, v;
+        private boolean pending;
+        private final int[] quad = new int[4];
+        private int count;
+
+        private void flush() {
+            if (!pending || mesh == null) return;
+            pending = false;
+
+            mesh.ensureQuadCapacity();
+            quad[count++] = mesh.vec3(x, y, z).vec2(u, v).color(color).next();
+
+            if (count == 4) {
+                mesh.quad(quad[0], quad[1], quad[2], quad[3]);
+                count = 0;
+            }
+        }
+
+        @Override
+        public VertexConsumer addVertex(float x, float y, float z) {
+            flush(); // finalize the previous vertex before starting a new one
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            pending = true;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int red, int green, int blue, int alpha) {
+            color.set(red, green, blue, alpha);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int argb) {
+            color.set(
+                (argb >> 16) & 0xFF,
+                (argb >> 8) & 0xFF,
+                argb & 0xFF,
+                (argb >> 24) & 0xFF);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv(float u, float v) {
+            this.u = u;
+            this.v = v;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv1(int u, int v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv2(int u, int v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setNormal(float x, float y, float z) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setLineWidth(float width) {
+            return this;
+        }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -256,6 +256,7 @@ public class BetterChat extends Module {
     @EventHandler
     private void onMessageReceive(ReceiveMessageEvent event) {
         Component message = event.getMessage();
+        Component original = message;
 
         if (filterRegex.get()) {
             String messageString = message.getString();
@@ -297,7 +298,9 @@ public class BetterChat extends Module {
             message = Component.empty().append(timestamp).append(message);
         }
 
-        event.setMessage(message);
+        // Only flag the event modified when we actually changed the message. Calling setMessage
+        // unconditionally forced a 26.2 render path that blanked incoming messages.
+        if (message != original) event.setMessage(message);
     }
 
     @EventHandler

--- a/src/main/resources/meteor-client.classtweaker
+++ b/src/main/resources/meteor-client.classtweaker
@@ -10,6 +10,9 @@ accessible   class   net/minecraft/client/multiplayer/ClientChunkCache$Storage
 # SaveMapCommand#saveMap
 accessible   field   net/minecraft/client/resources/MapTextureManager$MapInstance texture Lnet/minecraft/client/renderer/texture/DynamicTexture;
 
+# LevelRendererMixin#meteor$pushEntityOutlineFramebuffer reassigns entityOutlineTarget (became final in 26.2)
+mutable      field   net/minecraft/client/renderer/LevelRenderer entityOutlineTarget Lcom/mojang/blaze3d/pipeline/RenderTarget;
+
 # BeaconScreenMixin#changeButtons
 accessible   class   net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconPowerButton
 accessible   class   net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconConfirmButton

--- a/src/stub/java/net/minecraft/util/Tuple.java
+++ b/src/stub/java/net/minecraft/util/Tuple.java
@@ -1,0 +1,26 @@
+package net.minecraft.util;
+
+/**
+ * Compile-only stub of the vanilla {@code net.minecraft.util.Tuple} class, which was removed in Minecraft 26.2
+ * but is still referenced by the Baritone API compiled against 26.1. Meteor never calls into it; this only lets
+ * javac resolve Baritone method signatures. It is NOT bundled in the mod jar (compileOnly stub sourceSet).
+ *
+ * Delete this stub and the associated build-script wiring once a 26.2 Baritone build is available.
+ */
+public class Tuple<A, B> {
+    private final A a;
+    private final B b;
+
+    public Tuple(A a, B b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public A getA() {
+        return a;
+    }
+
+    public B getB() {
+        return b;
+    }
+}


### PR DESCRIPTION
Small follow-up to your 26.2 work (#6439) that gets it building and running.

Two files were the only things left uncompiled:

1. **VanillaTextRenderer** reimplemented against 26.2's deferred text pipeline (`Font.prepareText` -> `GlyphVisitor` -> `TextRenderable`), since `MultiBufferSource`/`drawInBatch` were removed. Routes vanilla glyphs through per-atlas `MeshBuilder` + the UI_TEXT `MeshRenderer` path (same path CustomTextRenderer uses). Marked as needs-visual-verification.
2. **`net.minecraft.util.Tuple` stub** as a compile-only sourceSet, because the (not-yet-26.2) Baritone API still references it. Not shipped in the jar.

With these the client builds and boots on 26.2 (tested on a full modpack). Feel free to squash/adjust however fits your branch.